### PR TITLE
switch to msgpack for secure serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 script: bundle exec rake
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - jruby-18mode # JRuby in 1.8 mode
-  - jruby-19mode # JRuby in 1.9 mode
+  - 2.5.1
+  - 2.4.4
+  - jruby-9.1.17.0
+  - jruby-9.2.0.0

--- a/README.md
+++ b/README.md
@@ -52,18 +52,38 @@ bf.include? "badda"
 #=> false
 ```
 
-Serialization is through [Marshal](http://ruby-doc.org/core-1.8.7/Marshal.html):
+Serialization can be done using [MessagePack](https://github.com/msgpack/msgpack-ruby):
+
+Notice, you'll need to require `bloomer/msgpackable` to enable serialization.
 
 ```ruby
+require 'bloomer/msgpackable'
 b = Bloomer.new(10)
 b.add("a")
-s = Marshal.dump(b)
-new_b = Marshal.load(s)
+s = b.to_msgpack
+new_b = Bloomer.from_msgpack(s)
 new_b.include? "a"
 #=> true
 ```
 
+The original class will be preserved regardless of calling `Bloomer.from_msgpack(s)` or `Bloomer::Scalable.from_msgpack(s)`:
+
+```ruby
+require 'bloomer/msgpackable'
+b = Bloomer::Scalable.new
+b.add("a")
+s = b.to_msgpack
+new_b = Bloomer.from_msgpack(s)
+new_b.class == Bloomer::Scalable
+#=> true
+```
+
+
+
 ## Changelog
+
+### 0.0.6
+* Using msgpack for more secure deserialization. Marshal.load still works but is not recommended
 
 ### 0.0.5
 * Switched from rspec to minitest

--- a/bloomer.gemspec
+++ b/bloomer.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "bitarray"
+  s.add_dependency "msgpack"
   s.add_development_dependency "rake"
   s.add_development_dependency "yard"
   s.add_development_dependency "minitest"

--- a/lib/bloomer/msgpackable.rb
+++ b/lib/bloomer/msgpackable.rb
@@ -1,0 +1,65 @@
+require "msgpack"
+
+module Msgpackable
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  def to_msgpack
+    self.class.msgpack_factory.dump self
+  end
+
+  module ClassMethods
+    def from_msgpack(data)
+      msgpack_factory.load(data)
+    end
+
+    def msgpack_factory
+      @msgpack_factory ||= ::MessagePack::Factory.new.tap do |factory|
+        factory.register_type(0x01, ::Bloomer)
+        factory.register_type(0x02, ::Bloomer::Scalable)
+        factory.freeze
+      end
+    end
+  end
+end
+
+# Patch Bloomer and Scalable to make them msgpackable
+class Bloomer
+  include Msgpackable
+
+  def to_msgpack_ext
+    self.class.msgpack_factory.dump([@capacity, @count, @k, @ba.size, @ba.field])
+  end
+
+  def from_msgpack_ext(capacity, count, k, ba_size, ba_field)
+    @capacity, @count, @k = capacity, count, k
+    @ba = BitArray.new(ba_size, ba_field)
+  end
+
+  def self.from_msgpack_ext(data)
+    values = msgpack_factory.load(data)
+    ::Bloomer.new(values[1]).tap do |b|
+      b.from_msgpack_ext(*values)
+    end
+  end
+
+  class Scalable
+    include Msgpackable
+
+    def to_msgpack_ext
+      self.class.msgpack_factory.dump([@false_positive_probability, @bloomers])
+    end
+
+    def from_msgpack_ext(false_positive_probability, bloomers)
+      @false_positive_probability, @bloomers = false_positive_probability, bloomers
+    end
+
+    def self.from_msgpack_ext(data)
+      false_positive_probability, bloomers = msgpack_factory.load(data)
+      ::Bloomer::Scalable.new.tap do |b|
+        b.from_msgpack_ext(false_positive_probability, bloomers)
+      end
+    end
+  end
+end


### PR DESCRIPTION
MessagePack is a small and efficient binary format without the dangers of Marshal.load

I've separated all msgpack functionality into it's own module. To use it, that module must be included separately (see the updated README).

Also added tests for msgpack'ing both `Bloomer` and `Scalable`
